### PR TITLE
Re-fix: Grouped filters with filterCount%2==0 are flipped

### DIFF
--- a/library/src/jp/co/cyberagent/android/gpuimage/GPUImageFilterGroup.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/GPUImageFilterGroup.java
@@ -42,7 +42,6 @@ public class GPUImageFilterGroup extends GPUImageFilter {
 
     private final FloatBuffer mGLCubeBuffer;
     private final FloatBuffer mGLTextureBuffer;
-    private final FloatBuffer mGLTextureFlipBuffer;
 
     /**
      * Instantiates a new GPUImageFilterGroup with no filters.
@@ -73,12 +72,6 @@ public class GPUImageFilterGroup extends GPUImageFilter {
                 .order(ByteOrder.nativeOrder())
                 .asFloatBuffer();
         mGLTextureBuffer.put(TEXTURE_NO_ROTATION).position(0);
-
-        float[] flipTexture = TextureRotationUtil.getRotation(Rotation.NORMAL, false, true);
-        mGLTextureFlipBuffer = ByteBuffer.allocateDirect(flipTexture.length * 4)
-                .order(ByteOrder.nativeOrder())
-                .asFloatBuffer();
-        mGLTextureFlipBuffer.put(flipTexture).position(0);
     }
 
     public void addFilter(GPUImageFilter aFilter) {
@@ -199,8 +192,6 @@ public class GPUImageFilterGroup extends GPUImageFilter {
 
                 if (i == 0) {
                     filter.onDraw(previousTexture, cubeBuffer, textureBuffer);
-                } else if (i == size - 1) {
-                    filter.onDraw(previousTexture, mGLCubeBuffer, (size % 2 == 0) ? mGLTextureFlipBuffer : mGLTextureBuffer);
                 } else {
                     filter.onDraw(previousTexture, mGLCubeBuffer, mGLTextureBuffer);
                 }

--- a/library/src/jp/co/cyberagent/android/gpuimage/OpenGlUtils.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/OpenGlUtils.java
@@ -20,6 +20,7 @@ import java.nio.IntBuffer;
 
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
+import android.graphics.Matrix;
 import android.hardware.Camera.Size;
 import android.opengl.GLES20;
 import android.opengl.GLUtils;
@@ -34,6 +35,9 @@ public class OpenGlUtils {
 
     public static int loadTexture(final Bitmap img, final int usedTexId, final boolean recycle) {
         int textures[] = new int[1];
+
+        Bitmap flippedBitmap = flipBitmap(img);
+
         if (usedTexId == NO_TEXTURE) {
             GLES20.glGenTextures(1, textures, 0);
             GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textures[0]);
@@ -46,15 +50,18 @@ public class OpenGlUtils {
             GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D,
                     GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
 
-            GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, img, 0);
+            GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, flippedBitmap, 0);
         } else {
             GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, usedTexId);
-            GLUtils.texSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, img);
+            GLUtils.texSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, flippedBitmap);
             textures[0] = usedTexId;
         }
         if (recycle) {
             img.recycle();
         }
+
+        flippedBitmap.recycle();
+
         return textures[0];
     }
 
@@ -137,5 +144,11 @@ public class OpenGlUtils {
     public static float rnd(final float min, final float max) {
         float fRandNum = (float) Math.random();
         return min + (max - min) * fRandNum;
+    }
+
+    private static Bitmap flipBitmap(Bitmap bitmap) {
+        Matrix flip = new Matrix();
+        flip.postScale(1f, -1f);
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), flip, true);
     }
 }

--- a/library/src/jp/co/cyberagent/android/gpuimage/util/TextureRotationUtil.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/util/TextureRotationUtil.java
@@ -21,29 +21,29 @@ import jp.co.cyberagent.android.gpuimage.Rotation;
 public class TextureRotationUtil {
 
     public static final float TEXTURE_NO_ROTATION[] = {
-            0.0f, 1.0f,
-            1.0f, 1.0f,
             0.0f, 0.0f,
             1.0f, 0.0f,
+            0.0f, 1.0f,
+            1.0f, 1.0f,
     };
 
     public static final float TEXTURE_ROTATED_90[] = {
-            1.0f, 1.0f,
             1.0f, 0.0f,
-            0.0f, 1.0f,
+            1.0f, 1.0f,
             0.0f, 0.0f,
+            0.0f, 1.0f,
     };
     public static final float TEXTURE_ROTATED_180[] = {
-            1.0f, 0.0f,
-            0.0f, 0.0f,
             1.0f, 1.0f,
             0.0f, 1.0f,
+            1.0f, 0.0f,
+            0.0f, 0.0f,
     };
     public static final float TEXTURE_ROTATED_270[] = {
-            0.0f, 0.0f,
             0.0f, 1.0f,
-            1.0f, 0.0f,
+            0.0f, 0.0f,
             1.0f, 1.0f,
+            1.0f, 0.0f,
     };
 
     private TextureRotationUtil() {


### PR DESCRIPTION
We should flip bitmap once instead of flipping scene for every filter in a group.