### PR TITLE
Optimise converting PixelBuffer to Bitmap

### DIFF
--- a/library/src/jp/co/cyberagent/android/gpuimage/PixelBuffer.java
+++ b/library/src/jp/co/cyberagent/android/gpuimage/PixelBuffer.java
@@ -32,6 +32,7 @@ import javax.microedition.khronos.egl.EGLSurface;
 import javax.microedition.khronos.opengles.GL10;
 
 import android.graphics.Bitmap;
+import android.graphics.Matrix;
 import android.opengl.GLSurfaceView;
 import android.util.Log;
 
@@ -189,22 +190,16 @@ public class PixelBuffer {
     }
 
     private void convertToBitmap() {
-        int[] iat = new int[mWidth * mHeight];
         IntBuffer ib = IntBuffer.allocate(mWidth * mHeight);
         mGL.glReadPixels(0, 0, mWidth, mHeight, GL_RGBA, GL_UNSIGNED_BYTE, ib);
-        int[] ia = ib.array();
-
-        //Stupid !
-        // Convert upside down mirror-reversed image to right-side up normal
-        // image.
-        for (int i = 0; i < mHeight; i++) {
-            for (int j = 0; j < mWidth; j++) {
-                iat[(mHeight - i - 1) * mWidth + j] = ia[i * mWidth + j];
-            }
-        }
-        
 
         mBitmap = Bitmap.createBitmap(mWidth, mHeight, Bitmap.Config.ARGB_8888);
-        mBitmap.copyPixelsFromBuffer(IntBuffer.wrap(iat));
+        mBitmap.copyPixelsFromBuffer(ib);
+
+        // Convert upside down mirror-reversed image to right-side up normal
+        // image.
+        Matrix matrix = new Matrix();
+        matrix.preScale(1.0f, -1.0f);
+        mBitmap = Bitmap.createBitmap(mBitmap, 0, 0, mWidth, mHeight, matrix, false);
     }
 }


### PR DESCRIPTION
Removes the need to create 2 extra int[] of equal size to the Bitmap, and
uses a Matrix instead to correct the Bitmap transformation, which ends up
being more efficient. Closes #285 