### PR TITLE
Fix gradle scipts to use latest android build tools and ndkBuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ obj/
 apk/
 target/
 build/
+.externalNativeBuild
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -3,17 +3,19 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
-        classpath 'com.novoda:bintray-release:0.3.4'
+        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.novoda:bintray-release:0.7.0'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
-        maven { url("https://oss.sonatype.org/content/repositories/snapshots/") }
+        google()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,3 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=cyberagent
 POM_DEVELOPER_NAME=CyberAgent, Inc.
 ISSUE_URL=https://github.com/CyberAgent/android-gpuimage/issues
-
-android.useDeprecatedNdk=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Dec 06 18:27:05 JST 2014
+#Wed Nov 01 16:57:07 KST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip

--- a/library/Android.mk
+++ b/library/Android.mk
@@ -1,0 +1,15 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := gpuimage-library
+LOCAL_LDFLAGS := -Wl,--build-id
+LOCAL_LDLIBS := \
+	-llog \
+
+LOCAL_SRC_FILES := \
+	jni/yuv-decoder.c \
+
+LOCAL_C_INCLUDES += jni
+LOCAL_C_INCLUDES += src/debug/jni
+
+include $(BUILD_SHARED_LIBRARY)

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -17,7 +17,8 @@ android {
         ndk {
             moduleName "gpuimage-library"
             stl "gnustl_shared"
-            abiFilters "all"
+            abiFilters = []
+            abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a'
             ldLibs "log"
         }
     }
@@ -39,6 +40,12 @@ android {
 
     lintOptions {
         abortOnError false
+    }
+    buildToolsVersion '26.0.2'
+    externalNativeBuild {
+        ndkBuild {
+            path 'Android.mk'
+        }
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -26,9 +26,11 @@ android {
     lintOptions {
         abortOnError true
     }
+    buildToolsVersion '26.0.2'
 }
 repositories {
     jcenter()
+    google()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 


### PR DESCRIPTION
Changes:
- Upgrade gradle version. (to 4.2.1)
- Upgrade Android build tools. (to 26.0.2)
- Configure NdkBuild with Android.mk. (Not to use android.useDeprecatedNdk option which is deprecated)